### PR TITLE
Complex

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,37 @@
+{
+  "env": {
+    "browser": true
+  },
+  "globals": {
+    "require": true,
+    "module": true,
+    "$": false,
+    "process": true
+  },
+  "rules": {
+    "quotes": "single",
+    "new-cap": 0,
+    "comma-dangle": 0,
+    "global-strict": 0,
+    "strict": [2, "global"],
+    "no-underscore-dangle": 0,
+    "max-depth": [2, 4],
+    "max-params": [2, 4],
+    "complexity": [2, 15],
+    "max-nested-callbacks": [2, 3],
+    "no-debugger": 1,
+    "curly": 2,
+    "radix": 2,
+    "brace-style": [2, "1tbs", { "allowSingleLine": true }],
+    "key-spacing": 2,
+    "no-constant-condition": 1,
+    "no-unreachable": 2,
+    "no-nested-ternary": 2,
+    "space-after-function-name": [2, "never"],
+    "space-before-blocks": [2, "always"],
+    "no-else-return": 2,
+    "no-console": 1,
+    "no-sparse-arrays": 2,
+    "no-mixed-spaces-and-tabs": 2
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,10 @@ dist:
 	$(browserify) ./src/main.js --standalone Baz | $(derequire) > ./dist/bazooka.js
 
 example:
-	mkdir -p examples/basic/dist/ examples/react-basic/dist/
+	mkdir -p examples/basic/dist/ examples/react-basic/dist/ examples/complex/dist/
 	$(browserify) examples/basic/app.js -r ./dist/bazooka.js:'bazooka' > examples/basic/dist/app.bundle.js
 	$(browserify) examples/react-basic/app.js -r ./dist/bazooka.js:'bazooka' -r ./examples/react-basic/vendor/react.min.js:'react'  > examples/react-basic/dist/app.bundle.js
+	$(browserify) examples/complex/app.js -r ./dist/bazooka.js:'bazooka' -r ./examples/complex/baz-complex.js:'baz-complex' -r ./examples/complex/baz-logger.js:'baz-logger'  > examples/complex/dist/app.bundle.js
 
 test:
 	$(karma) start $(karma_conf) --single-run

--- a/examples/complex/app.js
+++ b/examples/complex/app.js
@@ -1,0 +1,3 @@
+'use strict';
+
+require('bazooka').parseNodes();

--- a/examples/complex/baz-complex.js
+++ b/examples/complex/baz-complex.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var Baz = require('bazooka');
+
+function bazFunc(node) {
+  var $baz = Baz(node);
+
+  node.onclick = function () {
+    $baz.g('info')('clicked', $baz.id);
+  };
+}
+
+module.exports = {
+  f: bazFunc,
+
+  deps: [
+    'baz-logger'
+  ]
+};

--- a/examples/complex/baz-logger.js
+++ b/examples/complex/baz-logger.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var Baz = require('bazooka');
+
+function bazFunc(node) {
+  var $baz = Baz(node);
+
+  $baz.r('info', console.info.bind(console, '[baz-logger]'));
+}
+
+module.exports = bazFunc;

--- a/examples/complex/index.html
+++ b/examples/complex/index.html
@@ -4,7 +4,8 @@
     <title></title>
 </head>
 <body>
-    <div data-bazooka="baz-complex"></div>
+    <div data-bazooka="baz-complex">click me</div>
+    <div data-bazooka="baz-complex">or me</div>
 
     <script type="text/javascript" src="dist/app.bundle.js"></script>
 </body>

--- a/examples/complex/index.html
+++ b/examples/complex/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+    <title></title>
+</head>
+<body>
+    <div data-bazooka="baz-complex"></div>
+
+    <script type="text/javascript" src="dist/app.bundle.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -41,7 +41,5 @@
     "phantomjs": "^1.9.16",
     "proxyquireify": "^1.2.2"
   },
-  "dependencies": {
-    "domready": "^1.0.7"
-  }
+  "dependencies": {}
 }

--- a/spec/main/mainSpec.js
+++ b/spec/main/mainSpec.js
@@ -5,7 +5,7 @@ function appendDiv() {
     return node;
 }
 
-describe("main", function() {
+describe("Baz", function() {
     var Baz = require('../../src/main.js');
 
     beforeEach(function() {
@@ -21,54 +21,27 @@ describe("main", function() {
         );
     });
 
-    it("should run component function", function(done) {
+    it("should return wrapper node", function () {
         var node = appendDiv();
-        node.setAttribute('data-bazooka', 'testComponent');
-
-        var component = function (element, opts) {
-            done();
-        };
-
-        Baz({
-            'testComponent': component
-        });
+        var $baz = Baz(node);
+        expect($baz instanceof Baz.wrapper).toBe(true);
     });
 
-    it("should fail on empty apps", function() {
-        var noAppsError = new Error('Bazooka: No applications found!');
-        expect(function () { Baz() }).toThrow(noAppsError);
-        expect(function () { Baz(null) }).toThrow(noAppsError);
-        expect(function () { Baz({}) }).toThrow(noAppsError);
+    it("should increment bazId for new node", function () {
+        var node = appendDiv();
+        var $baz = Baz(node);
+
+        var node2 = appendDiv();
+        var $baz2 = Baz(node2);
+
+        expect($baz2.id).toBe($baz.id + 1);
     });
 
-    it("should parse attributes to opts", function(done) {
+    it("should do nothing to bazId of already wrapped nodes", function () {
         var node = appendDiv();
-        node.setAttribute('data-bazooka', 'testComponent');
-        node.setAttribute('data-bazooka-attr-one', 1);
-        node.setAttribute('data-bazooka-attr-two', 'two');
-        node.setAttribute('data-bazooka-attr-three-zero', null);
+        var $baz = Baz(node);
+        var $baz2 = Baz(node);
 
-        var component = function (element, opts) {
-            expect(Object.keys(opts).length).toBe(3);
-            expect(opts.one).toBe('1');
-            expect(opts.two).toBe('two');
-            expect(opts.threeZero).toBe('null');
-            done();
-        };
-
-        Baz({
-            'testComponent': component
-        });
-    });
-
-    it("should print warnings if app does not found in HTML nodes", function() {
-        var node = appendDiv();
-        node.setAttribute('data-bazookamisspelled', 'testComponent');
-
-        Baz({
-            'testComponent': function () {}
-        });
-
-        expect(console.warn).toHaveBeenCalledWith('Bazooka: testComponent not found in HTML nodes');
+        expect($baz2.id).toBe($baz.id);
     });
 });

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,11 @@
+'use strict';
+
 var domready = require('domready');
 
 if (!Function.prototype.bind) {
     // Credits to https://github.com/kdimatteo/bind-polyfill
     // Solves https://github.com/ariya/phantomjs/issues/10522
+    /* eslint-disable no-extend-native */
     Function.prototype.bind = function (oThis) {
         if (typeof this !== "function") {
             // closest thing possible to the ECMAScript 5 internal IsCallable function
@@ -24,6 +27,7 @@ if (!Function.prototype.bind) {
 
         return fBound;
     };
+    /* eslint-enable no-extend-native */
 }
 
 function _camelize(match, p1) { return p1.toUpperCase(); }
@@ -44,30 +48,28 @@ function _bindAppToNode(app, node) {
 function _bindApps(apps) {
     var _this = this;
 
-    for (var app_name in apps) {
+    for (var appName in apps) {
         // Avoid a Chakra JIT bug in compatibility modes of IE 11.
         // See https://github.com/jashkenas/underscore/issues/1621 for more details.
-        if (!(typeof apps[app_name] == 'function' || false)) {
-            throw new Error('Bazooka: ' + app_name + ' is not callable!');
+        if (!(typeof apps[appName] === 'function' || false)) {
+            throw new Error('Bazooka: ' + appName + ' is not callable!');
         }
 
-        var app_nodes = document.querySelectorAll("[data-bazooka*='" + app_name + "']");
-        if (!(app_nodes.length)) {
-            console.warn('Bazooka: ' + app_name + ' not found in HTML nodes');
+        var appNodes = document.querySelectorAll("[data-bazooka*='" + appName + "']");
+        if (!(appNodes.length)) {
+            console.warn('Bazooka: ' + appName + ' not found in HTML nodes');
             continue;
         }
 
         Array.prototype.forEach.call(
-            app_nodes,
-            _bindAppToNode.bind(_this, apps[app_name])
+            appNodes,
+            _bindAppToNode.bind(_this, apps[appName])
         );
     }
 
 }
 
-Bazooka = function (apps) {
-    'use strict';
-
+var Bazooka = function (apps) {
     if (!(apps && Object.keys(apps).length)) {
         throw new Error('Bazooka: No applications found!');
     }


### PR DESCRIPTION
Implementation for #7

This changes brake basic and basic-react examples and change Baz and BazComp APIs:

```javascript
Baz => new BazookaWrapper
Baz.wrapper => BazookaWrapper
Baz.parseNodes = function () {}

BazookaWrapper
BazookaWrapper.g = function (methodName) { return function }
BazookaWrapper.r = function (methodName, method) {}
```

```javascript
BazComp = function (node) {}
BazComp = {
  f: function (node) {},
  deps: []string,
}
```