### PR TITLE
remove polyfills from `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "karma": "^0.13.15",
     "karma-jasmine": "^0.3.6",
     "karma-phantomjs-launcher": "^0.2.1",
+    "karma-phantomjs-shim": "^1.2.0",
     "karma-webpack": "^1.7.0",
     "kefir": "^3.1.0",
     "lodash": "^3.10.1",
@@ -43,9 +44,5 @@
     "react": "^0.14.2",
     "react-dom": "^0.14.2",
     "webpack": "^1.12.3"
-  },
-  "dependencies": {
-    "function-bind": "^1.0.2",
-    "mutation-observer": "^1.0.1"
   }
 }

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -5,7 +5,7 @@ module.exports = function(config) {
   config.set({
     basePath: '',
 
-    frameworks: ['jasmine'],
+    frameworks: ['jasmine', 'phantomjs-shim'],
 
     files: [
       '**/*Spec.js'
@@ -33,7 +33,8 @@ module.exports = function(config) {
     plugins: [
       'karma-webpack',
       'karma-jasmine',
-      'karma-phantomjs-launcher'
+      'karma-phantomjs-launcher',
+      'karma-phantomjs-shim'
     ],
 
     webpack: {

--- a/src/main.js
+++ b/src/main.js
@@ -1,22 +1,5 @@
 'use strict';
 
-// polyfills
-/* eslint-disable no-extend-native, no-undef */
-var MutationObserver = window.MutationObserver
-  || window.WebKitMutationObserver
-  || window.MozMutationObserver;
-
-if (!MutationObserver) {
-  MutationObserver = require('mutation-observer');
-}
-
-if (!Function.prototype.bind) {
-  Function.prototype.bind = require('function-bind');
-}
-/* eslint-enable no-extend-native, no-undef */
-// /polyfills
-
-
 var _bazId = 0;
 var nodesComponentsRegistry = {};
 var componentsRegistry = {};


### PR DESCRIPTION
closes #29

After a merge, we’ll need to include info about MutationObserver requirement to the README