### PR TITLE
Bazooka.rebind; support for bazFunc.dispose

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ $ cd examples
 * **gifflix** — bazooka + frp (via [kefir.js](https://rpominov.github.io/kefir/))
 
 
-## [Docs](docs/README.md)
+## [Docs](docs)
+- [API](docs/README.md)
+- [Hot Reloadable `bazFunc`s](docs/hot-reloadable-bazfuncs.md)
 
 ## [Changelog](CHANGELOG.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,15 +24,16 @@ Interface of component, required by [Bazooka.refresh](#module_Bazooka.refresh)
 
 
 * [BazComponent](#module_BazComponent)
-    * [~simple](#module_BazComponent..simple)
+    * [~simple](#module_BazComponent..simple) ⇒ <code>function</code>
     * [~universal](#module_BazComponent..universal)
 
 <a name="module_BazComponent..simple"></a>
 
-### BazComponent~simple
+### BazComponent~simple ⇒ <code>function</code>
 CommonJS module written only with Bazooka interface to be used with `data-bazooka`
 
 **Kind**: inner interface of <code>[BazComponent](#module_BazComponent)</code>  
+**Returns**: <code>function</code> - `dispose` callback to cleanup components `eventListeners`, timers, etc. after [Bazooka.rebind](#module_Bazooka.rebind) or removal of the node from DOM  
 
 | Type | Description |
 | --- | --- |
@@ -185,8 +186,8 @@ Helper method to preserve component's state between Webpack's hot module reloads
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleHot | <code>webpackHotModule</code> | — [module.hot](https://github.com/webpack/webpack/blob/e7c13d75e4337cf166d421c153804892c49511bd/lib/HotModuleReplacement.runtime.js#L80) of the component |
-| stateCallback | <code>[HMRStateCallback](#HMRStateCallback)</code> | — callback to create state. Called with undefined `prev` on initial binding and with `prev` equal latest component state after every HMR |
+| moduleHot | <code>webpackHotModule</code> | [module.hot](https://github.com/webpack/webpack/blob/e7c13d75e4337cf166d421c153804892c49511bd/lib/HotModuleReplacement.runtime.js#L80) of the component |
+| stateCallback | <code>[HMRStateCallback](#HMRStateCallback)</code> | callback to create state. Called with undefined `prev` on initial binding and with `prev` equal latest component state after every HMR |
 
 **Example**  
 ```javascript

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,14 @@
 </dd>
 </dl>
 
+## Typedefs
+
+<dl>
+<dt><a href="#HMRStateCallback">HMRStateCallback</a> ⇒ <code>Object</code></dt>
+<dd><p>Callback to get state between Webpack&#39;s hot module reloads (HMR)</p>
+</dd>
+</dl>
+
 <a name="module_BazComponent"></a>
 
 ## BazComponent
@@ -69,6 +77,7 @@ Bazooka
     * _static_
         * [.register(componentsObj)](#module_Bazooka.register)
         * [.refresh([rootNode])](#module_Bazooka.refresh)
+        * [.rebind(componentsObj)](#module_Bazooka.rebind)
         * [.watch([rootNode])](#module_Bazooka.watch) ⇒ <code>function</code>
     * _inner_
         * [~BazookaWrapper](#module_Bazooka..BazookaWrapper)
@@ -95,6 +104,33 @@ Parse and bind bazooka components to nodes without bound components
 | --- | --- | --- | --- |
 | [rootNode] | <code>node</code> | <code>document.body</code> | DOM node, children of which will be checked for `data-bazooka` |
 
+<a name="module_Bazooka.rebind"></a>
+
+### Bazooka.rebind(componentsObj)
+Rebind existing components. Nodes with already bound component will be [disposed](BazFunc.dispose) and bound again to a new `bazFunc`
+
+**Kind**: static method of <code>[Bazooka](#module_Bazooka)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| componentsObj | <code>Object</code> | object with new components |
+
+**Example**  
+```javascript
+  import bazFunc from './bazFunc.js'
+
+  Baz.register({
+    bazFunc: bazFunc,
+  });
+
+  Baz.watch();
+
+  if (module.hot) {
+    module.hot.accept('./bazFunc.js', () => Baz.rebind({ bazFunc: bazFunc }));
+    // or, if you prefer `require()`
+    // module.hot.accept('./bazFunc.js', () => Baz.rebind({ bazFunc: require('./bazFunc.js') }));
+  }
+```
 <a name="module_Bazooka.watch"></a>
 
 ### Bazooka.watch([rootNode]) ⇒ <code>function</code>
@@ -113,12 +149,48 @@ Watch for new nodes with `data-bazooka`. No need to run [Bazooka.refresh](#modul
 Reference to [BazookaWrapper](#BazookaWrapper) class
 
 **Kind**: inner property of <code>[Bazooka](#module_Bazooka)</code>  
+<a name="HMRStateCallback"></a>
+
+## HMRStateCallback ⇒ <code>Object</code>
+Callback to get state between Webpack's hot module reloads (HMR)
+
+**Kind**: global typedef  
+**Returns**: <code>Object</code> - whatever state should be after HMR  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| previous | <code>Object</code> | state. `undefined` on first call |
+
 <a name="BazookaWrapper"></a>
 
 ## ~BazookaWrapper
 **Kind**: inner class  
+
+* [~BazookaWrapper](#BazookaWrapper)
+    * [.getComponents()](#BazookaWrapper+getComponents) ⇒ <code>Object.&lt;string, BazComponent&gt;</code>
+    * [.HMRState(moduleHot, stateCallback)](#BazookaWrapper+HMRState) ⇒ <code>Object</code>
+
 <a name="BazookaWrapper+getComponents"></a>
 
 ### bazookaWrapper.getComponents() ⇒ <code>Object.&lt;string, BazComponent&gt;</code>
 **Kind**: instance method of <code>[BazookaWrapper](#BazookaWrapper)</code>  
 **Returns**: <code>Object.&lt;string, BazComponent&gt;</code> - object of the bound to the wrapped node [BazComponents](#module_BazComponent)  
+<a name="BazookaWrapper+HMRState"></a>
+
+### bazookaWrapper.HMRState(moduleHot, stateCallback) ⇒ <code>Object</code>
+Helper method to preserve component's state between Webpack's hot module reloads (HMR)
+
+**Kind**: instance method of <code>[BazookaWrapper](#BazookaWrapper)</code>  
+**Returns**: <code>Object</code> - value from `stateCallback`  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| moduleHot | <code>webpackHotModule</code> | — [module.hot](https://github.com/webpack/webpack/blob/e7c13d75e4337cf166d421c153804892c49511bd/lib/HotModuleReplacement.runtime.js#L80) of the component |
+| stateCallback | <code>[HMRStateCallback](#HMRStateCallback)</code> | — callback to create state. Called with undefined `prev` on initial binding and with `prev` equal latest component state after every HMR |
+
+**Example**  
+```javascript
+  const state = module.hot
+    ? Baz(node).HMRState(module.hot, prev => prev || model())
+    : model();
+```

--- a/docs/hot-reloadable-bazfuncs.md
+++ b/docs/hot-reloadable-bazfuncs.md
@@ -1,0 +1,51 @@
+# Hot reloadable `bazFunc`s
+
+To make a component hot reloadable, you will need to:
+1. (optionally) return `dispose` function from `bazFunc`. This function cleans up eventListeners, timers, etc.
+```diff
+import model from './model.js';
+
+export default function hotBaz(node) {
+  const state = model();
+
+  render(node, state);
+  node.addEventListener('click', clickHandler);
+
++  return () => {
++    node.removeEventListener('click', boundHandler);
++  };
+};
+```
+2. (optionally) call `Baz(node).HMRState(moduleHot, stateCallback)` method to preserve `state` between hot reloads. `stateCallback` is called without arguments on initial execution and with preserved state after each hot reload
+```diff
++import Baz from 'bazooka';
+import model from './model.js';
+
+export default function hotBaz(node) {
+-  const state = model();
++  const state = module.hot
++    ? Baz(node).HMRState(module.hot, prev => prev || model())
++    : model();
+
+  mockRerender(node, state);
+
+  const boundHandler = clickHandler(node, state);
+  node.addEventListener('click', boundHandler);
+
+  return () => {
+    node.removeEventListener('click', boundHandler);
+  };
+}
+```
+3. write `module.hot.accept` handler in init script ("near" `Baz.watch`/`Baz.refresh`), which calls new `Baz.rebind` function
+```diff
+import component from './component.js';
+
+Baz.register({ 'hot-component': component });
+Baz.watch();
+
++if (module.hot) {
++  module.hot.accept('./component.js', () =>
++    Baz.rebind({ 'hot-component': component }));
++}
+```

--- a/examples/_hot/component.js
+++ b/examples/_hot/component.js
@@ -1,0 +1,32 @@
+import view from './view.js';
+
+function mockRerender(node, state) {
+  node.textContent = view(state);
+}
+
+function clickHandler(node, state) {
+  return function(event) {
+    // modify this expression for some HOT magic
+    state.count = state.count + 1;
+    mockRerender(node, state);
+  };
+}
+
+let hotComponent = function hotComponent(node, prevState) {
+  const state = prevState || {
+    count: 1,
+  };
+
+  mockRerender(node, state);
+
+  const boundHandler = clickHandler(node, state);
+  node.addEventListener('click', boundHandler);
+
+  return () => {
+    node.removeEventListener('click', boundHandler);
+
+    return state;
+  };
+};
+
+export default hotComponent;

--- a/examples/_hot/component.js
+++ b/examples/_hot/component.js
@@ -16,7 +16,9 @@ function clickHandler(node, state) {
 }
 
 export default function hotComponent(node) {
-  const state = module.hot ? Baz(node).HMRState(module.hot, model()) : model();
+  const state = module.hot
+    ? Baz(node).HMRState(module.hot, prev => prev || model())
+    : model();
 
   if (module.hot) {
     // reload page if `./model.js` is changed

--- a/examples/_hot/component.js
+++ b/examples/_hot/component.js
@@ -1,4 +1,7 @@
+import Baz from 'bazooka';
+
 import view from './view.js';
+import model from './model.js';
 
 function mockRerender(node, state) {
   node.textContent = view(state);
@@ -12,10 +15,11 @@ function clickHandler(node, state) {
   };
 }
 
-let hotComponent = function hotComponent(node, prevState) {
-  const state = prevState || {
-    count: 1,
-  };
+export default function hotComponent(node) {
+  const state = module.hot
+    ? Baz(node).HMRState(module.hot, model(), () =>
+        module.hot.decline('./model.js'))
+    : model();
 
   mockRerender(node, state);
 
@@ -24,9 +28,5 @@ let hotComponent = function hotComponent(node, prevState) {
 
   return () => {
     node.removeEventListener('click', boundHandler);
-
-    return state;
   };
-};
-
-export default hotComponent;
+}

--- a/examples/_hot/component.js
+++ b/examples/_hot/component.js
@@ -16,13 +16,11 @@ function clickHandler(node, state) {
 }
 
 export default function hotComponent(node) {
-  const state = module.hot
-    ? Baz(node).HMRState(module.hot, model())
-    : model();
+  const state = module.hot ? Baz(node).HMRState(module.hot, model()) : model();
 
   if (module.hot) {
     // reload page if `./model.js` is changed
-    module.hot.decline('./model.js')
+    module.hot.decline('./model.js');
   }
 
   mockRerender(node, state);

--- a/examples/_hot/component.js
+++ b/examples/_hot/component.js
@@ -17,9 +17,13 @@ function clickHandler(node, state) {
 
 export default function hotComponent(node) {
   const state = module.hot
-    ? Baz(node).HMRState(module.hot, model(), () =>
-        module.hot.decline('./model.js'))
+    ? Baz(node).HMRState(module.hot, model())
     : model();
+
+  if (module.hot) {
+    // reload page if `./model.js` is changed
+    module.hot.decline('./model.js')
+  }
 
   mockRerender(node, state);
 

--- a/examples/_hot/index.html
+++ b/examples/_hot/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title></title>
+</head>
+<body>
+    <button data-bazooka="hot-component">...</button>
+
+    <script type="text/javascript" src="http://localhost:8080/dist/bundle.js"></script>
+</body>
+</html>

--- a/examples/_hot/index.js
+++ b/examples/_hot/index.js
@@ -1,0 +1,13 @@
+import Baz from 'bazooka';
+import component from './component.js';
+
+Baz.register({
+  'hot-component': component,
+});
+
+Baz.watch();
+
+if (module.hot) {
+  module.hot.accept('./component.js', () =>
+    Baz.rebind({ 'hot-component': component }));
+}

--- a/examples/_hot/model.js
+++ b/examples/_hot/model.js
@@ -1,0 +1,5 @@
+export default function model() {
+  return {
+    count: 10,
+  };
+}

--- a/examples/_hot/package.json
+++ b/examples/_hot/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "_hot",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "webpack": "webpack",
+    "start" : "webpack-dev-server"
+  },
+  "devDependencies": {
+    "webpack": "^2.3.3",
+    "webpack-dev-server": "^2.4.2"
+  }
+}

--- a/examples/_hot/view.js
+++ b/examples/_hot/view.js
@@ -1,0 +1,2 @@
+// modify this text for some HOT magic
+export default state => '- ' + state.count + ' -';

--- a/examples/_hot/webpack.config.js
+++ b/examples/_hot/webpack.config.js
@@ -1,0 +1,32 @@
+const { resolve } = require('path');
+const webpack = require('webpack');
+
+module.exports = {
+  context: __dirname,
+
+  entry: [
+    'webpack-dev-server/client?http://localhost:8080',
+    'webpack/hot/only-dev-server',
+    './index.js',
+  ],
+  output: {
+    filename: 'bundle.js',
+    path: resolve(__dirname, 'dist'),
+    publicPath: '/dist',
+  },
+
+  devtool: 'inline-source-map',
+
+  devServer: {
+    hot: true,
+    contentBase: __dirname,
+    publicPath: '/dist',
+  },
+
+  module: {},
+
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NamedModulesPlugin(),
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bazooka",
-  "version": "0.6.1",
+  "version": "0.7.0-0",
   "description": "Simple tool for declarative binding applications to HTML nodes.",
   "main": "src/main.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bazooka",
-  "version": "0.7.0-0",
+  "version": "0.7.0-1",
   "description": "Simple tool for declarative binding applications to HTML nodes.",
   "main": "src/main.js",
   "directories": {

--- a/spec/main/mainRebindSpec.js
+++ b/spec/main/mainRebindSpec.js
@@ -93,4 +93,35 @@ describe('Baz.rebind', function() {
     expect(disposeSpy).toHaveBeenCalledWith(node);
     expect(disposeSpy).toHaveBeenCalledWith(node2);
   });
+
+  it('should call bazFuncs a correct number of times', function() {
+    var node = appendDiv();
+    var node2 = appendDiv();
+    var node3 = appendDiv();
+    node.setAttribute('data-bazooka', 'exampleBazFunc');
+    node2.setAttribute('data-bazooka', 'exampleBazFunc2');
+    node3.setAttribute('data-bazooka', 'exampleBazFunc exampleBazFunc2');
+    Baz.refresh();
+
+    componentsRegistry.exampleBazFunc.calls.reset();
+    componentsRegistry.exampleBazFunc2.calls.reset();
+
+    var disposeSpy = jasmine.createSpy('dispose');
+    var newRegisterObj = {
+      exampleBazFunc: function(node) {
+        return function() {
+          disposeSpy(node);
+        };
+      },
+    };
+    spyOn(newRegisterObj, 'exampleBazFunc').and.callThrough();
+
+    Baz.rebind(newRegisterObj);
+    expect(disposeSpy.calls.count()).toEqual(0);
+    expect(newRegisterObj.exampleBazFunc.calls.count()).toEqual(2);
+    expect(componentsRegistry.exampleBazFunc.calls.count()).toEqual(0);
+    expect(componentsRegistry.exampleBazFunc2.calls.count()).toEqual(0);
+    expect(newRegisterObj.exampleBazFunc).toHaveBeenCalledWith(node);
+    expect(newRegisterObj.exampleBazFunc).toHaveBeenCalledWith(node3);
+  });
 });

--- a/spec/main/mainRebindSpec.js
+++ b/spec/main/mainRebindSpec.js
@@ -1,0 +1,96 @@
+'use strict';
+
+function appendDiv() {
+  var node = document.createElement('div');
+  node.setAttribute('test-node', '');
+  document.body.appendChild(node);
+  return node;
+}
+
+var componentsRegistry = {
+  exampleBazFunc: function() {},
+  exampleBazFunc2: function() {},
+};
+
+describe('Baz.rebind', function() {
+  var Baz = require('bazooka');
+
+  beforeEach(function() {
+    spyOn(componentsRegistry, 'exampleBazFunc').and.callThrough();
+    spyOn(componentsRegistry, 'exampleBazFunc2').and.callThrough();
+    Baz.register(componentsRegistry);
+  });
+
+  afterEach(function() {
+    Array.prototype.forEach.call(
+      document.querySelectorAll('[test-node]'),
+      function(el) {
+        document.body.removeChild(el);
+      }
+    );
+  });
+
+  it('should rebind only new components', function() {
+    var node = appendDiv();
+    var node2 = appendDiv();
+    node.setAttribute('data-bazooka', 'exampleBazFunc');
+    node2.setAttribute('data-bazooka', 'exampleBazFunc exampleBazFunc2');
+    Baz.refresh();
+
+    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(node);
+    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(node2);
+    expect(componentsRegistry.exampleBazFunc2).toHaveBeenCalledWith(node2);
+
+    componentsRegistry.exampleBazFunc.calls.reset();
+    componentsRegistry.exampleBazFunc2.calls.reset();
+
+    var newRegisterObj = {
+      exampleBazFunc: function(node) {},
+    };
+    spyOn(newRegisterObj, 'exampleBazFunc').and.callThrough();
+
+    Baz.rebind(newRegisterObj);
+
+    expect(componentsRegistry.exampleBazFunc.calls.count()).toEqual(0);
+    expect(componentsRegistry.exampleBazFunc2.calls.count()).toEqual(0);
+    expect(newRegisterObj.exampleBazFunc).toHaveBeenCalledWith(node);
+    expect(newRegisterObj.exampleBazFunc).toHaveBeenCalledWith(node2);
+
+    newRegisterObj.exampleBazFunc.calls.reset();
+
+    Baz.rebind({ exampleBazFunc: componentsRegistry.exampleBazFunc });
+
+    expect(newRegisterObj.exampleBazFunc.calls.count()).toEqual(0);
+    expect(componentsRegistry.exampleBazFunc2.calls.count()).toEqual(0);
+    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(node);
+    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(node2);
+  });
+
+  it('should call dispose', function() {
+    var node = appendDiv();
+    var node2 = appendDiv();
+    node.setAttribute('data-bazooka', 'exampleBazFunc');
+    node2.setAttribute('data-bazooka', 'exampleBazFunc exampleBazFunc2');
+    Baz.refresh();
+
+    componentsRegistry.exampleBazFunc.calls.reset();
+    componentsRegistry.exampleBazFunc2.calls.reset();
+
+    var disposeSpy = jasmine.createSpy('dispose');
+    var newRegisterObj = {
+      exampleBazFunc: function(node) {
+        return function() {
+          disposeSpy(node);
+        };
+      },
+    };
+    spyOn(newRegisterObj, 'exampleBazFunc').and.callThrough();
+
+    Baz.rebind(newRegisterObj);
+    expect(disposeSpy.calls.count()).toEqual(0);
+
+    Baz.rebind({ exampleBazFunc: componentsRegistry.exampleBazFunc });
+    expect(disposeSpy).toHaveBeenCalledWith(node);
+    expect(disposeSpy).toHaveBeenCalledWith(node2);
+  });
+});

--- a/spec/main/mainSpec.js
+++ b/spec/main/mainSpec.js
@@ -44,7 +44,10 @@ describe('Baz', function() {
     node.setAttribute('data-bazooka', 'exampleBazFunc');
     Baz.refresh();
 
-    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(node);
+    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(
+      node,
+      void 0
+    );
   });
 
   it('should not bind incorrect component to node', function() {
@@ -62,7 +65,7 @@ describe('Baz', function() {
 
     expect(
       componentsRegistry.exampleComplexBazComponent.bazFunc
-    ).toHaveBeenCalledWith(node);
+    ).toHaveBeenCalledWith(node, void 0);
   });
 
   it('should bind multiple components to node', function() {
@@ -73,10 +76,13 @@ describe('Baz', function() {
     );
     Baz.refresh();
 
-    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(node);
+    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(
+      node,
+      void 0
+    );
     expect(
       componentsRegistry.exampleComplexBazComponent.bazFunc
-    ).toHaveBeenCalledWith(node);
+    ).toHaveBeenCalledWith(node, void 0);
     expect(componentsRegistry.exampleBazFunc2).not.toHaveBeenCalled();
   });
 
@@ -91,11 +97,23 @@ describe('Baz', function() {
     );
     Baz.refresh();
 
-    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(node);
-    expect(componentsRegistry.exampleBazFunc2).toHaveBeenCalledWith(node);
+    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(
+      node,
+      void 0
+    );
+    expect(componentsRegistry.exampleBazFunc2).toHaveBeenCalledWith(
+      node,
+      void 0
+    );
 
-    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(node2);
-    expect(componentsRegistry.exampleBazFunc2).toHaveBeenCalledWith(node2);
+    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(
+      node2,
+      void 0
+    );
+    expect(componentsRegistry.exampleBazFunc2).toHaveBeenCalledWith(
+      node2,
+      void 0
+    );
   });
 
   it('should bind bazFuncless component to node', function() {

--- a/spec/main/mainSpec.js
+++ b/spec/main/mainSpec.js
@@ -44,10 +44,7 @@ describe('Baz', function() {
     node.setAttribute('data-bazooka', 'exampleBazFunc');
     Baz.refresh();
 
-    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(
-      node,
-      void 0
-    );
+    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(node);
   });
 
   it('should not bind incorrect component to node', function() {
@@ -65,7 +62,7 @@ describe('Baz', function() {
 
     expect(
       componentsRegistry.exampleComplexBazComponent.bazFunc
-    ).toHaveBeenCalledWith(node, void 0);
+    ).toHaveBeenCalledWith(node);
   });
 
   it('should bind multiple components to node', function() {
@@ -76,13 +73,10 @@ describe('Baz', function() {
     );
     Baz.refresh();
 
-    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(
-      node,
-      void 0
-    );
+    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(node);
     expect(
       componentsRegistry.exampleComplexBazComponent.bazFunc
-    ).toHaveBeenCalledWith(node, void 0);
+    ).toHaveBeenCalledWith(node);
     expect(componentsRegistry.exampleBazFunc2).not.toHaveBeenCalled();
   });
 
@@ -97,23 +91,11 @@ describe('Baz', function() {
     );
     Baz.refresh();
 
-    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(
-      node,
-      void 0
-    );
-    expect(componentsRegistry.exampleBazFunc2).toHaveBeenCalledWith(
-      node,
-      void 0
-    );
+    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(node);
+    expect(componentsRegistry.exampleBazFunc2).toHaveBeenCalledWith(node);
 
-    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(
-      node2,
-      void 0
-    );
-    expect(componentsRegistry.exampleBazFunc2).toHaveBeenCalledWith(
-      node2,
-      void 0
-    );
+    expect(componentsRegistry.exampleBazFunc).toHaveBeenCalledWith(node2);
+    expect(componentsRegistry.exampleBazFunc2).toHaveBeenCalledWith(node2);
   });
 
   it('should bind bazFuncless component to node', function() {

--- a/spec/main/mainThrowSpec.js
+++ b/spec/main/mainThrowSpec.js
@@ -1,6 +1,4 @@
 'use strict';
-/* global describe, beforeEach, afterEach, it, expect, spyOn */
-/* eslint max-nested-callbacks:0 */
 
 function appendDiv() {
   var node = document.createElement('div');

--- a/spec/main/mainThrowSpec.js
+++ b/spec/main/mainThrowSpec.js
@@ -41,7 +41,7 @@ describe('Baz', function() {
     node.setAttribute('data-bazooka', 'goodBazFunc');
     Baz.refresh();
 
-    expect(componentsRegistry.goodBazFunc).toHaveBeenCalledWith(node);
+    expect(componentsRegistry.goodBazFunc).toHaveBeenCalledWith(node, void 0);
   });
 
   it('should catch error from errorousBazFunc', function() {
@@ -54,7 +54,10 @@ describe('Baz', function() {
       Baz.refresh();
     }).toThrow();
 
-    expect(componentsRegistry.errorousBazFunc).toHaveBeenCalledWith(node);
+    expect(componentsRegistry.errorousBazFunc).toHaveBeenCalledWith(
+      node,
+      void 0
+    );
   });
 
   it('error from errorousBazFunc should not stop goodBazFunc', function() {
@@ -71,13 +74,22 @@ describe('Baz', function() {
       Baz.refresh();
     }).toThrow();
 
-    expect(componentsRegistry.errorousBazFunc).toHaveBeenCalledWith(node);
-    expect(componentsRegistry.errorousBazFunc).toHaveBeenCalledWith(node2);
-    expect(componentsRegistry.errorousBazFunc).not.toHaveBeenCalledWith(node3);
+    expect(componentsRegistry.errorousBazFunc).toHaveBeenCalledWith(
+      node,
+      void 0
+    );
+    expect(componentsRegistry.errorousBazFunc).toHaveBeenCalledWith(
+      node2,
+      void 0
+    );
+    expect(componentsRegistry.errorousBazFunc).not.toHaveBeenCalledWith(
+      node3,
+      void 0
+    );
 
-    expect(componentsRegistry.goodBazFunc).toHaveBeenCalledWith(node);
-    expect(componentsRegistry.goodBazFunc).toHaveBeenCalledWith(node2);
-    expect(componentsRegistry.goodBazFunc).toHaveBeenCalledWith(node3);
+    expect(componentsRegistry.goodBazFunc).toHaveBeenCalledWith(node, void 0);
+    expect(componentsRegistry.goodBazFunc).toHaveBeenCalledWith(node2, void 0);
+    expect(componentsRegistry.goodBazFunc).toHaveBeenCalledWith(node3, void 0);
 
     expect(node.getAttribute('data-called')).toBe('yes');
     expect(node2.getAttribute('data-called')).toBe('yes');
@@ -93,7 +105,10 @@ describe('Baz', function() {
     expect(function() {
       Baz.refresh();
     }).toThrow();
-    expect(componentsRegistry.errorousBazFunc).toHaveBeenCalledWith(node);
+    expect(componentsRegistry.errorousBazFunc).toHaveBeenCalledWith(
+      node,
+      void 0
+    );
 
     Baz.refresh();
   });

--- a/spec/main/mainThrowSpec.js
+++ b/spec/main/mainThrowSpec.js
@@ -41,7 +41,7 @@ describe('Baz', function() {
     node.setAttribute('data-bazooka', 'goodBazFunc');
     Baz.refresh();
 
-    expect(componentsRegistry.goodBazFunc).toHaveBeenCalledWith(node, void 0);
+    expect(componentsRegistry.goodBazFunc).toHaveBeenCalledWith(node);
   });
 
   it('should catch error from errorousBazFunc', function() {
@@ -54,10 +54,7 @@ describe('Baz', function() {
       Baz.refresh();
     }).toThrow();
 
-    expect(componentsRegistry.errorousBazFunc).toHaveBeenCalledWith(
-      node,
-      void 0
-    );
+    expect(componentsRegistry.errorousBazFunc).toHaveBeenCalledWith(node);
   });
 
   it('error from errorousBazFunc should not stop goodBazFunc', function() {
@@ -74,22 +71,13 @@ describe('Baz', function() {
       Baz.refresh();
     }).toThrow();
 
-    expect(componentsRegistry.errorousBazFunc).toHaveBeenCalledWith(
-      node,
-      void 0
-    );
-    expect(componentsRegistry.errorousBazFunc).toHaveBeenCalledWith(
-      node2,
-      void 0
-    );
-    expect(componentsRegistry.errorousBazFunc).not.toHaveBeenCalledWith(
-      node3,
-      void 0
-    );
+    expect(componentsRegistry.errorousBazFunc).toHaveBeenCalledWith(node);
+    expect(componentsRegistry.errorousBazFunc).toHaveBeenCalledWith(node2);
+    expect(componentsRegistry.errorousBazFunc).not.toHaveBeenCalledWith(node3);
 
-    expect(componentsRegistry.goodBazFunc).toHaveBeenCalledWith(node, void 0);
-    expect(componentsRegistry.goodBazFunc).toHaveBeenCalledWith(node2, void 0);
-    expect(componentsRegistry.goodBazFunc).toHaveBeenCalledWith(node3, void 0);
+    expect(componentsRegistry.goodBazFunc).toHaveBeenCalledWith(node);
+    expect(componentsRegistry.goodBazFunc).toHaveBeenCalledWith(node2);
+    expect(componentsRegistry.goodBazFunc).toHaveBeenCalledWith(node3);
 
     expect(node.getAttribute('data-called')).toBe('yes');
     expect(node2.getAttribute('data-called')).toBe('yes');
@@ -105,10 +93,7 @@ describe('Baz', function() {
     expect(function() {
       Baz.refresh();
     }).toThrow();
-    expect(componentsRegistry.errorousBazFunc).toHaveBeenCalledWith(
-      node,
-      void 0
-    );
+    expect(componentsRegistry.errorousBazFunc).toHaveBeenCalledWith(node);
 
     Baz.refresh();
   });

--- a/spec/main/wrapperHMRSpec.js
+++ b/spec/main/wrapperHMRSpec.js
@@ -1,0 +1,82 @@
+'use strict';
+
+function appendDiv() {
+  var node = document.createElement('div');
+  node.setAttribute('test-node', '');
+  document.body.appendChild(node);
+  return node;
+}
+
+describe('BazookaWrapper.prototype.HMRState', function() {
+  var Baz = require('bazooka');
+
+  afterEach(function() {
+    Array.prototype.forEach.call(
+      document.querySelectorAll('[test-node]'),
+      function(el) {
+        document.body.removeChild(el);
+      }
+    );
+  });
+
+  it('should return initial state', function() {
+    var node = appendDiv();
+    node.setAttribute('data-bazooka', 'bazFunc');
+
+    var checker = jasmine.createSpy('checker');
+    var mockModuleHot = {
+      dispose: function() {},
+      data: {},
+    };
+
+    var registerObj = {
+      bazFunc: function(node) {
+        var state = Baz(node).HMRState(mockModuleHot, function(prev) {
+          return prev || { count: 0 };
+        });
+        checker(state.count);
+        state.count++;
+      },
+    };
+
+    Baz.register(registerObj);
+    Baz.refresh();
+
+    expect(checker.calls.allArgs()).toEqual([[0]]);
+  });
+
+  it('should save and load data between HMRs', function() {
+    var node = appendDiv();
+    node.setAttribute('data-bazooka', 'bazFunc');
+
+    var checker = jasmine.createSpy('checker');
+    var mockModuleHot = {
+      dispose: function(cb) {
+        mockModuleHot.disposes.push(cb);
+      },
+      data: {},
+      disposes: [],
+    };
+
+    var registerObj = {
+      bazFunc: function(node) {
+        var state = Baz(node).HMRState(mockModuleHot, function(prev) {
+          return prev || { count: 0 };
+        });
+        checker(state.count);
+        state.count++;
+      },
+    };
+
+    Baz.register(registerObj);
+    Baz.refresh();
+
+    mockModuleHot.disposes.forEach(function(cb) {
+      cb(mockModuleHot.data);
+    });
+    mockModuleHot.disposes = [];
+
+    Baz.rebind(registerObj);
+    expect(checker.calls.allArgs()).toEqual([[0], [1]]);
+  });
+});

--- a/spec/main/wrapperSpec.js
+++ b/spec/main/wrapperSpec.js
@@ -1,6 +1,4 @@
 'use strict';
-/* global describe, beforeEach, afterEach, it, expect, spyOn */
-/* eslint max-nested-callbacks:0 */
 
 function appendDiv() {
   var node = document.createElement('div');

--- a/src/main.js
+++ b/src/main.js
@@ -45,6 +45,8 @@ function _applyComponentToNode(componentName, wrappedNode) {
 
     if (typeof dispose === 'function') {
       wrappedNode.__disposesMap__[componentName] = dispose;
+    } else if (wrappedNode.__disposesMap__[componentName]) {
+      wrappedNode.__disposesMap__[componentName] = null;
     }
   }
 }
@@ -113,9 +115,11 @@ BazookaWrapper.prototype.dispose = function() {
 BazookaWrapper.prototype.HMRState = function(moduleHot, stateCallback) {
   // moduleHot is bazFunc's `module.hot` (with method related to *that* bazFunc)
   var state;
-  moduleHot.dispose(function(data) {
-    data[this.id] = state;
-  });
+  moduleHot.dispose(
+    function(data) {
+      data[this.id] = state;
+    }.bind(this)
+  );
 
   if (moduleHot.data && moduleHot.data[this.id]) {
     state = stateCallback(moduleHot.data[this.id]);
@@ -297,6 +301,10 @@ Bazooka.rebind = function rebind(componentsObj) {
   for (var componentName in componentsObj) {
     for (var bazId in wrappersRegistry) {
       wrappedNode = wrappersRegistry[bazId];
+
+      if (!wrappedNode) {
+        continue;
+      }
 
       if (
         wrappedNode &&

--- a/src/main.js
+++ b/src/main.js
@@ -110,15 +110,18 @@ BazookaWrapper.prototype.dispose = function() {
   nodesComponentsRegistry[this.id] = [];
 };
 
-BazookaWrapper.prototype.HMRState = function(moduleHot, state) {
+BazookaWrapper.prototype.HMRState = function(moduleHot, stateCallback) {
   // moduleHot is bazFunc's `module.hot` (with method related to *that* bazFunc)
+  var state;
   moduleHot.dispose(function(data) {
     data[this.id] = state;
   });
 
   if (moduleHot.data && moduleHot.data[this.id]) {
-    state = moduleHot.data[this.id];
+    state = stateCallback(moduleHot.data[this.id]);
     moduleHot.data[this.id] = null;
+  } else {
+    state = stateCallback();
   }
 
   return state;

--- a/src/main.js
+++ b/src/main.js
@@ -110,7 +110,7 @@ BazookaWrapper.prototype.dispose = function() {
   nodesComponentsRegistry[this.id] = [];
 };
 
-BazookaWrapper.prototype.HMRState = function(moduleHot, state, cb) {
+BazookaWrapper.prototype.HMRState = function(moduleHot, state) {
   // moduleHot is bazFunc's `module.hot` (with method related to *that* bazFunc)
   moduleHot.dispose(function(data) {
     data[this.id] = state;
@@ -119,10 +119,6 @@ BazookaWrapper.prototype.HMRState = function(moduleHot, state, cb) {
   if (moduleHot.data && moduleHot.data[this.id]) {
     state = moduleHot.data[this.id];
     moduleHot.data[this.id] = null;
-  }
-
-  if (cb) {
-    cb();
   }
 
   return state;

--- a/src/main.js
+++ b/src/main.js
@@ -188,7 +188,7 @@ function _wrapAndBindNode(node) {
  * @interface
  * @param {node} - bound DOM node
  * @description CommonJS module written only with Bazooka interface to be used with `data-bazooka`
- * @returns {function} `dispose` callback to cleanup components `eventListeners`, timers, etc. after [Bazooka.rebind]{@link module:Bazooka.rebind} or removal of the node from DOM
+ * @returns {function} `dispose` callback to cleanup component's `eventListeners`, timers, etc. after [Bazooka.rebind]{@link module:Bazooka.rebind} or removal of the node from DOM
  * @example
  * ```javascript
  *   module.exports = function bazFunc(node) {}
@@ -217,7 +217,7 @@ function _wrapAndBindNode(node) {
  * @func
  * @param {node} - bound DOM node
  * @description Component's binding function
- * @returns {function} `dispose` callback to cleanup components `eventListeners`, timers, etc. after [Bazooka.rebind]{@link module:Bazooka.rebind} or removal of the node from DOM
+ * @returns {function} `dispose` callback to cleanup component's `eventListeners`, timers, etc. after [Bazooka.rebind]{@link module:Bazooka.rebind} or removal of the node from DOM
  */
 
 /**

--- a/src/main.js
+++ b/src/main.js
@@ -110,8 +110,8 @@ BazookaWrapper.prototype.getComponents = function() {
 
 /**
  * Helper method to preserve component's state between Webpack's hot module reloads (HMR)
- * @param {webpackHotModule} moduleHot — [module.hot](https://github.com/webpack/webpack/blob/e7c13d75e4337cf166d421c153804892c49511bd/lib/HotModuleReplacement.runtime.js#L80) of the component
- * @param {HMRStateCallback} stateCallback — callback to create state. Called with undefined `prev` on initial binding and with `prev` equal latest component state after every HMR
+ * @param {webpackHotModule} moduleHot - [module.hot](https://github.com/webpack/webpack/blob/e7c13d75e4337cf166d421c153804892c49511bd/lib/HotModuleReplacement.runtime.js#L80) of the component
+ * @param {HMRStateCallback} stateCallback - callback to create state. Called with undefined `prev` on initial binding and with `prev` equal latest component state after every HMR
  * @example
  * ```javascript
  *   const state = module.hot
@@ -188,6 +188,7 @@ function _wrapAndBindNode(node) {
  * @interface
  * @param {node} - bound DOM node
  * @description CommonJS module written only with Bazooka interface to be used with `data-bazooka`
+ * @returns {function} `dispose` callback to cleanup components `eventListeners`, timers, etc. after [Bazooka.rebind]{@link module:Bazooka.rebind} or removal of the node from DOM
  * @example
  * ```javascript
  *   module.exports = function bazFunc(node) {}
@@ -216,6 +217,7 @@ function _wrapAndBindNode(node) {
  * @func
  * @param {node} - bound DOM node
  * @description Component's binding function
+ * @returns {function} `dispose` callback to cleanup components `eventListeners`, timers, etc. after [Bazooka.rebind]{@link module:Bazooka.rebind} or removal of the node from DOM
  */
 
 /**

--- a/src/main.js
+++ b/src/main.js
@@ -26,12 +26,12 @@ function _bindComponentToNode(wrappedNode, componentName) {
     return;
   }
 
-  if (nodesComponentsRegistry[bazId] === void 0) {
-    nodesComponentsRegistry[bazId] = [];
+  if (!nodesComponentsRegistry[bazId]) {
+    nodesComponentsRegistry[bazId] = {};
   }
 
-  if (nodesComponentsRegistry[bazId].indexOf(componentName) === -1) {
-    nodesComponentsRegistry[bazId].push(componentName);
+  if (!nodesComponentsRegistry[bazId][componentName]) {
+    nodesComponentsRegistry[bazId][componentName] = true;
   }
 }
 
@@ -91,10 +91,8 @@ BazookaWrapper.prototype.constructor = BazookaWrapper;
 BazookaWrapper.prototype.getComponents = function() {
   var components = {};
 
-  for (var i = 0; i < nodesComponentsRegistry[this.id].length; i++) {
-    components[nodesComponentsRegistry[this.id][i]] = _getComponent(
-      nodesComponentsRegistry[this.id][i]
-    );
+  for (var componentName in nodesComponentsRegistry[this.id]) {
+    components[componentName] = _getComponent(componentName);
   }
 
   return components;
@@ -154,9 +152,7 @@ function _wrapAndBindNode(node) {
       _bindComponentToNode(wrappedNode, componentNames[i].trim());
     }
 
-    for (var i = 0; i < nodesComponentsRegistry[wrappedNode.id].length; i++) {
-      componentName = nodesComponentsRegistry[wrappedNode.id][i];
-
+    for (var componentName in nodesComponentsRegistry[wrappedNode.id]) {
       try {
         _applyComponentToNode(componentName, wrappedNode);
       } catch (e) {
@@ -288,7 +284,7 @@ Bazooka.refresh = function(rootNode) {
       }
 
       wrappersRegistry[bazId] = null;
-      nodesComponentsRegistry[bazId] = [];
+      nodesComponentsRegistry[bazId] = {};
     }
     wrapper = null;
   }
@@ -345,6 +341,10 @@ Bazooka.rebind = function rebind(componentsObj) {
       wrappedNode = wrappersRegistry[bazId];
 
       if (!wrappedNode) {
+        continue;
+      }
+
+      if (!nodesComponentsRegistry[bazId][componentName]) {
         continue;
       }
 

--- a/webpack.config.examples.js
+++ b/webpack.config.examples.js
@@ -8,7 +8,8 @@ var EXAMPLES_BASE_DIR = path.join(__dirname, 'examples');
 
 var getDirectories = function(srcPath) {
   return fs.readdirSync(srcPath).filter(function(file) {
-    return fs.statSync(path.join(srcPath, file)).isDirectory();
+    return fs.statSync(path.join(srcPath, file)).isDirectory() &&
+      file.indexOf('_') !== 0;
   });
 };
 


### PR DESCRIPTION
closes #41 and #27 

<details>

- [x] `return dispose` (#27)
- [x] ~optional second argument for `bazFunc` to save state between hot reloads (state can be returned be `dispose`)~ replaced with `module.hot.data` based `BazookaWrapper.prototype.HMRState`
- [x] tests
- [x] update docs

</details>


To make a component hot reloadable, author will need to:
1. (optionally) return `dispose` function from `bazFunc`. This function cleans up eventListeners, timers, etc.
```diff
import model from './model.js';

export default function hotBaz(node) {
  const state = model();

  render(node, state);
  node.addEventListener('click', clickHandler);

+  return () => {
+    node.removeEventListener('click', boundHandler);
+  };
};
```
2. (optionally) call `Baz(node).HMRState(moduleHot, stateCallback)` method to preserve `state` between hot reloads. `stateCallback` is called without arguments on initial execution and with preserved state after each hot reload
```diff
+import Baz from 'bazooka';
import model from './model.js';

export default function hotBaz(node) {
-  const state = model();
+  const state = module.hot
+    ? Baz(node).HMRState(module.hot, prev => prev || model())
+    : model();

  mockRerender(node, state);

  const boundHandler = clickHandler(node, state);
  node.addEventListener('click', boundHandler);

  return () => {
    node.removeEventListener('click', boundHandler);
  };
}
```
3. write `module.hot.accept` handler in init script ("near" `Baz.watch`/`Baz.refresh`), which calls new `Baz.rebind` function
```diff
import component from './component.js';

Baz.register({ 'hot-component': component });
Baz.watch();

+if (module.hot) {
+  module.hot.accept('./component.js', () =>
+    Baz.rebind({ 'hot-component': component }));
+}
```